### PR TITLE
Use SO_REUSEADDR to quickly re-use addresses

### DIFF
--- a/src/SCTPasp_PT.cc
+++ b/src/SCTPasp_PT.cc
@@ -1492,10 +1492,13 @@ void SCTPasp__PT_PROVIDER::map_delete_item_server(int index)
 void SCTPasp__PT_PROVIDER::create_socket()
 {
   struct sockaddr_in  sin;
+  int enable = 1;
 
   log("Creating SCTP socket.");
   if ((fd = socket(AF_INET, SOCK_STREAM, IPPROTO_SCTP)) == -1)
     error("Socket error: cannot create socket!");
+
+  setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
 
   if ( local_port_is_present ) {
     sin.sin_family = AF_INET;


### PR DESCRIPTION
If a new test cases starts immediately after the old one ends, chances
are high it will want to bind the exact same IP/port again.

SO_REUSEADDR is the standard mechanism to achieve this.

Signed-off-by: Harald Welte <laforge@gnumonks.org>